### PR TITLE
Move to onEvent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -92,15 +92,11 @@ export const setupPlugin: GCSPlugin['setupPlugin'] = async ({ attachments, globa
     global.eventsToIgnore = new Set<string>((config.exportEventsToIgnore || '').split(',').map((event) => event.trim()))
 }
 
-export const exportEvents: GCSPlugin['exportEvents'] = async (events, { global, config }) => {
-    const rows = events.filter((event) => !global.eventsToIgnore.has(event.event.trim())).map(transformEventToRow)
-    if (rows.length) {
-        console.info(
-            `Saving batch of ${rows.length} event${rows.length !== 1 ? 's' : ''} to GCS bucket ${config.bucketName}`
-        )
-    } else {
-        console.info(`Skipping an empty batch of events`)
+export const onEvent: GCSPlugin['exportEvents'] = async (event, { global, config }) => {
+    if (global.eventsToIgnore.has(event.event.trim())) {
+        return
     }
+    const rows = [transformEventToRow(event)]
 
     let csvString =
         'uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n'


### PR DESCRIPTION
We're deprecating exportEvents and replacing it with batch exports or onEvent.
This plugin is rarely used and the load is quite low and and most of the events are sent alone already anyway.

Events in US today (EU is 10% of this):
<img width="272" alt="Screenshot 2023-09-20 at 16 43 21" src="https://github.com/PostHog/posthog-gcs-plugin/assets/890921/8d144321-919a-41d2-a0de-1cb434dc2c23">

